### PR TITLE
Implement menu actions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,5 +8,6 @@ project(UART_Command_Center)
 target_sources(app PRIVATE src/main.c
             src/uart_handler.c
             src/menu/menu_core.c
+            src/menu/menu_actions.c
 )
 target_include_directories(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/include/menu.h
+++ b/include/menu.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 void menu_core_run(void);
+extern void menu_actions_execute(int category, int action_id);
 
 #ifdef __cplusplus
 }

--- a/src/menu/menu_actions.c
+++ b/src/menu/menu_actions.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2024 UARTCommandCenter
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @file menu_actions.c
+ * @brief Menu action execution.
+ * 
+ * Description:
+ * ------------
+ * This file handles the execution of menu-related actions triggered by user input
+ * from the menu system. It acts as a dispatch center that translates user choices
+ * into meaningful operations, such as toggling lights, reading sensors, or 
+ * adjusting system configurations.
+ *
+ * The design goal is to keep "menu_actions.c" focused on the "what" (i.e., 
+ * which action to perform) rather than the "how" (implementation details). 
+ * The "how" is delegated to commands or drivers accessed through well-defined 
+ * interfaces.
+ * 
+ * @author Ameed Othman
+ * @date 2024-12-19
+ * 
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+#include "commands.h"
+#include "uart_handler.h"
+
+/*
+ * Register a logging module for menu actions. 
+ * Adjust the log level or name as appropriate for debugging.
+ */
+LOG_MODULE_REGISTER(menu_actions, LOG_LEVEL_INF);
+
+/**
+ * @brief Execute an action related to lights control.
+ *
+ * For example, this could toggle lights on or off, set brightness, or 
+ * perform more sophisticated lighting patterns. At this point, we may 
+ * just print a placeholder message or call a stub in "command_lights.c".
+ *
+ * @param command_id An identifier for the specific lights command, if needed.
+ */
+static void menu_actions_lights_control(int command_id)
+{
+	/* Placeholder: In the future, call a function from command_lights.c */
+	uart_handler_write_string("Lights action triggered (placeholder).\r\n");
+	LOG_INF("Lights control action executed (ID: %d)", command_id);
+}
+
+/**
+ * @brief Execute a sensor-related action, such as reading a sensor value 
+ *        and printing it to UART.
+ *
+ * @param sensor_type A code indicating which sensor to read (e.g., temperature, humidity).
+ */
+static void menu_actions_show_sensor_readings(int sensor_type)
+{
+	/* Placeholder: In the future, call functions from command_sensors.c or sensor_readings.c */
+	uart_handler_write_string("Sensor readings action triggered (placeholder).\r\n");
+	LOG_INF("Sensor readings displayed (Type: %d)", sensor_type);
+}
+
+/**
+ * @brief Execute a system configuration action, e.g., changing a parameter,
+ *        updating a mode, or performing calibration.
+ *
+ * @param config_id An identifier for the configuration action.
+ */
+static void menu_actions_system_configuration(int config_id)
+{
+	/* Placeholder: In the future, integrate with command_system.c */
+	uart_handler_write_string("System configuration action triggered (placeholder).\r\n");
+	LOG_INF("System configuration action executed (ID: %d)", config_id);
+}
+
+/**
+ * @brief Execute a diagnostics/log action, such as showing logs, system status,
+ *        or memory usage.
+ *
+ * @param diag_id An identifier to specify what type of diagnostics to perform.
+ */
+static void menu_actions_diagnostics(int diag_id)
+{
+	/* Placeholder: In the future, integrate with logging or diagnostics commands */
+	uart_handler_write_string("Diagnostics/logs action triggered (placeholder).\r\n");
+	LOG_INF("Diagnostics/log action executed (ID: %d)", diag_id);
+}
+
+/**
+ * @brief Public API to execute a menu action based on a given category and ID.
+ *
+ * The category could represent which submenu (lights, sensors, config, diagnostics)
+ * and the action_id could map to a specific operation within that category. This 
+ * approach makes the menu system modular and easy to extend.
+ *
+ * @param category Category of action (e.g., lights=1, sensors=2, config=3, diag=4).
+ * @param action_id Specific action ID within the category.
+ */
+void menu_actions_execute(int category, int action_id)
+{
+	LOG_INF("Executing menu action: category=%d, action_id=%d", category, action_id);
+
+	switch (category) {
+	case 1: /* Lights */
+		menu_actions_lights_control(action_id);
+		break;
+	case 2: /* Sensors */
+		menu_actions_show_sensor_readings(action_id);
+		break;
+	case 3: /* System Config */
+		menu_actions_system_configuration(action_id);
+		break;
+	case 4: /* Diagnostics */
+		menu_actions_diagnostics(action_id);
+		break;
+	default:
+		uart_handler_write_string("Invalid action category.\r\n");
+		LOG_WRN("Unknown action category: %d", category);
+		break;
+	}
+}

--- a/src/menu/menu_core.c
+++ b/src/menu/menu_core.c
@@ -88,16 +88,17 @@ static bool menu_core_handle_input(const char *input)
 {
 	if (strcmp(input, "1") == 0) {
 		uart_handler_write_string("Lights control selected.\r\n");
-		/* Future: call a function from command_lights.c or commands_core.c */
+        /* Test action: Category 1 for Lights, action_id = 0 as a placeholder */
+         menu_actions_execute(1, 0);
 	} else if (strcmp(input, "2") == 0) {
 		uart_handler_write_string("Sensor readings selected.\r\n");
-		/* Future: call a function from command_sensors.c */
+        menu_actions_execute(2, 0); // Category 2 for Sensors, action_id = 0
 	} else if (strcmp(input, "3") == 0) {
 		uart_handler_write_string("System configuration selected.\r\n");
-		/* Future: call a function from command_system.c */
+        menu_actions_execute(3, 0);
 	} else if (strcmp(input, "4") == 0) {
 		uart_handler_write_string("Diagnostics and logs selected.\r\n");
-		/* Future: call a function from commands_core.c or logger.c */
+        menu_actions_execute(4, 0);
 	} else if (strcmp(input, "0") == 0) {
 		uart_handler_write_string("Exiting menu.\r\n");
 		return false;  /* Stop the menu loop */


### PR DESCRIPTION
This PR introduces `menu_actions.c`, a new module that dispatches menu-selected operations to appropriate handlers. Although the implementations are currently placeholders, the integration has been tested successfully on both QEMU (Cortex-M3) and the STM32F446RE Nucleo board. Users can now select menu options to trigger corresponding actions, confirming that the framework is in place for future, fully implemented commands.