### PR TITLE
Implement commands core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,5 +10,6 @@ target_sources(app PRIVATE src/main.c
             src/menu/menu_core.c
             src/menu/menu_actions.c
             src/menu/menu_display.c
+            src/commands/commands_core.c
 )
 target_include_directories(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)

--- a/include/commands.h
+++ b/include/commands.h
@@ -1,0 +1,28 @@
+/**
+ * @file commands.h
+ * @brief Command execution interface.
+ * 
+ * @author Ameed Othman
+ * @date 2024-12-19
+ */
+
+#ifndef COMMANDS_H__
+#define COMMANDS_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Execute a command based on category and action_id.
+ *
+ * @param category Command category (1=Lights, 2=Sensors, 3=System, 4=Diagnostics)
+ * @param action_id Specific action within the category.
+ */
+void commands_core_execute(int category, int action_id);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* COMMANDS_H__ */

--- a/src/commands/commands_core.c
+++ b/src/commands/commands_core.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2024 UARTCommandCenter
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * @file commands_core.c
+ * @brief Centralized command execution.
+ * 
+ * Description:
+ * ------------
+ * This file provides a centralized interface for executing commands requested 
+ * by the menu system. It ties together the various command implementations 
+ * (e.g., lights, sensors, system configuration, diagnostics) into a unified 
+ * API. By doing this, the menu system and other components can trigger 
+ * high-level commands without needing to know the underlying implementation details.
+ * 
+ * @author Ameed Othman
+ * @date 2024-12-19
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+#include "commands.h"         // Public interface for commands (if defined)
+#include "uart_handler.h"     // For sending feedback if needed
+
+LOG_MODULE_REGISTER(commands_core, LOG_LEVEL_INF);
+
+/**
+ * @brief Execute a command for lights control.
+ *
+ * This function acts as a bridge to the lights command implementation.
+ * For now, it may just print a placeholder message. In the future, 
+ * it can call functions from "command_lights.c" to perform real actions.
+ *
+ * @param action_id Identifies which lights action to execute.
+ */
+static void commands_core_execute_lights(int action_id)
+{
+	uart_handler_write_string("Executing lights command (placeholder).\r\n");
+	LOG_INF("Lights command executed (ID: %d)", action_id);
+	/* Future: Integrate with command_lights.c functions */
+}
+
+/**
+ * @brief Execute a command for sensor operations.
+ *
+ * This function will route sensor-related requests to the appropriate 
+ * sensor reading or processing logic.
+ *
+ * @param action_id Identifies which sensor action to execute.
+ */
+static void commands_core_execute_sensors(int action_id)
+{
+	uart_handler_write_string("Executing sensor command (placeholder).\r\n");
+	LOG_INF("Sensor command executed (ID: %d)", action_id);
+	/* Future: Integrate with command_sensors.c functions */
+}
+
+/**
+ * @brief Execute a system configuration command.
+ *
+ * System commands might adjust configuration parameters, calibrate 
+ * devices, or change operation modes.
+ *
+ * @param action_id Identifies which system config action to execute.
+ */
+static void commands_core_execute_system(int action_id)
+{
+	uart_handler_write_string("Executing system config command (placeholder).\r\n");
+	LOG_INF("System config command executed (ID: %d)", action_id);
+	/* Future: Integrate with command_system.c functions */
+}
+
+/**
+ * @brief Execute a diagnostic or logging command.
+ *
+ * Diagnostics commands might show logs, memory usage, or other system 
+ * stats. This function will route those requests accordingly.
+ *
+ * @param action_id Identifies which diagnostic action to execute.
+ */
+static void commands_core_execute_diagnostics(int action_id)
+{
+	uart_handler_write_string("Executing diagnostics command (placeholder).\r\n");
+	LOG_INF("Diagnostics command executed (ID: %d)", action_id);
+	/* Future: Integrate with diagnostic or logger functions directly */
+}
+
+/**
+ * @brief Public API to execute a command based on a given category and action ID.
+ *
+ * This function provides a unified entry point for the menu system (or other 
+ * parts of the application) to request that a certain command be executed.
+ *
+ * @param category The command category (1=Lights, 2=Sensors, 3=System config, 4=Diagnostics)
+ * @param action_id The specific action within that category.
+ */
+void commands_core_execute(int category, int action_id)
+{
+	LOG_INF("commands_core_execute: category=%d, action_id=%d", category, action_id);
+
+	switch (category) {
+	case 1:
+		commands_core_execute_lights(action_id);
+		break;
+	case 2:
+		commands_core_execute_sensors(action_id);
+		break;
+	case 3:
+		commands_core_execute_system(action_id);
+		break;
+	case 4:
+		commands_core_execute_diagnostics(action_id);
+		break;
+	default:
+		uart_handler_write_string("Invalid command category.\r\n");
+		LOG_WRN("Unknown command category: %d", category);
+		break;
+	}
+}

--- a/src/menu/menu_actions.c
+++ b/src/menu/menu_actions.c
@@ -102,24 +102,11 @@ static void menu_actions_diagnostics(int diag_id)
  */
 void menu_actions_execute(int category, int action_id)
 {
-	LOG_INF("Executing menu action: category=%d, action_id=%d", category, action_id);
-
-	switch (category) {
-	case 1: /* Lights */
-		menu_actions_lights_control(action_id);
-		break;
-	case 2: /* Sensors */
-		menu_actions_show_sensor_readings(action_id);
-		break;
-	case 3: /* System Config */
-		menu_actions_system_configuration(action_id);
-		break;
-	case 4: /* Diagnostics */
-		menu_actions_diagnostics(action_id);
-		break;
-	default:
-		uart_handler_write_string("Invalid action category.\r\n");
-		LOG_WRN("Unknown action category: %d", category);
-		break;
-	}
+	LOG_INF("menu_actions_execute: category=%d, action_id=%d", category, action_id);
+	commands_core_execute(category, action_id);
+	/*
+	 * After calling commands_core_execute(), you will see the placeholders
+	 * defined in commands_core.c triggered. This confirms that the command
+	 * execution path is working end-to-end.
+	 */
 }

--- a/src/menu/menu_display.c
+++ b/src/menu/menu_display.c
@@ -39,8 +39,7 @@
 LOG_MODULE_REGISTER(menu_display, LOG_LEVEL_INF);
 
 /* 
- * A header template for the main menu or other menus.
- * You may consider storing various templates or styles here.
+ * A header template for the main menu.
  */
 static const char *main_menu_header =
 	"\r\n"
@@ -51,8 +50,7 @@ static const char *main_menu_header =
 /**
  * @brief Print the main menu options to the user.
  *
- * This function displays a predefined list of menu items. You can easily 
- * modify this to accept parameters or to build menus dynamically in the future.
+ * This function displays a predefined list of menu items.
  */
 void menu_display_show_main_menu(void)
 {


### PR DESCRIPTION
This PR enhances the command execution workflow by integrating `commands_core_execute()` into the menu actions. Now, when users select options from the menu, the actions are routed through `menu_actions.c` into `commands_core.c`, where placeholders currently reside. This centralized command execution structure makes it easier to add or modify commands without changing the menu or action layers.

Key points:
- `menu_actions_execute()` now calls `commands_core_execute()`, ensuring all commands follow the same execution path.
- Tested successfully on both QEMU and Nucleo-F446RE hardware, confirming that placeholder commands trigger correctly.